### PR TITLE
Swerve Drive Mathmatics

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -2,7 +2,12 @@
     "configurations": [
         {
             "name": "Test",
-            "defines": ["${default}", "ENV_UNIT_TESTS", "PLATFORM_HOSTED", "RUN_WITH_PROFILING"],
+            "defines": [
+                "${default}",
+                "ENV_UNIT_TESTS",
+                "PLATFORM_HOSTED",
+                "RUN_WITH_PROFILING"
+            ],
             "includePath": [
                 "${default}",
                 "aimbots-dev/taproot/sim-modm/hosted-linux/modm/src",
@@ -10,17 +15,25 @@
                 "aimbots-dev/test"
             ],
             "intelliSenseMode": "gcc-x64",
-            "browse": { "limitSymbolsToIncludedHeaders": true }
+            "browse": {
+                "limitSymbolsToIncludedHeaders": true
+            }
         },
         {
             "name": "Sim",
-            "defines": ["${default}", "PLATFORM_HOSTED", "RUN_WITH_PROFILING"],
+            "defines": [
+                "${default}",
+                "PLATFORM_HOSTED",
+                "RUN_WITH_PROFILING"
+            ],
             "includePath": [
                 "${default}",
                 "aimbots-dev/taproot/sim-modm/hosted-linux/modm/src"
             ],
             "intelliSenseMode": "gcc-x64",
-            "browse": { "limitSymbolsToIncludedHeaders": true }
+            "browse": {
+                "limitSymbolsToIncludedHeaders": true
+            }
         },
         {
             "name": "Hardware",
@@ -29,10 +42,14 @@
                 "aimbots-dev/taproot/modm/src",
                 "aimbots-dev/taproot/modm/ext/cmsis/core",
                 "aimbots-dev/taproot/modm/ext/cmsis/device",
-                "aimbots-dev/taproot/modm/ext/cmsis/dsp"        
+                "aimbots-dev/taproot/modm/ext/cmsis/dsp",
+                "/Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk/usr/include/c++/v1",
+                "/Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk/System/Library/Frameworks/Kernel.framework/Versions/A/Headers"
             ],
             "intelliSenseMode": "gcc-arm",
-            "browse": { "limitSymbolsToIncludedHeaders": true }
+            "browse": {
+                "limitSymbolsToIncludedHeaders": true
+            }
         }
     ],
     "version": 4

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -17,7 +17,9 @@
             "intelliSenseMode": "gcc-x64",
             "browse": {
                 "limitSymbolsToIncludedHeaders": true
-            }
+            },
+            "cStandard": "c17",
+            "cppStandard": "c++20"
         },
         {
             "name": "Sim",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -71,7 +71,8 @@
         "SConstruct": "python",
         "SConscript": "python",
         "__locale": "cpp",
-        "__string": "cpp"
+        "__string": "cpp",
+        "matrix_text": "cpp"
     },
     "C_Cpp.errorSquiggles": "Enabled",
     "C_Cpp.default.includePath": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -69,7 +69,9 @@
         "valarray": "cpp",
         "variant": "cpp",
         "SConstruct": "python",
-        "SConscript": "python"
+        "SConscript": "python",
+        "__locale": "cpp",
+        "__string": "cpp"
     },
     "C_Cpp.errorSquiggles": "Enabled",
     "C_Cpp.default.includePath": [

--- a/aimbots-dev/SConstruct
+++ b/aimbots-dev/SConstruct
@@ -146,6 +146,10 @@ if args["PROFILING"] == "true":
 # Add target-specific flags
 if args["TARGET_ENV"] == "sim":
     env.AppendUnique(CPPFLAGS=["-DPLATFORM_HOSTED"])
+    env.AppendUnique(CPPPATH=[
+        abspath(r"taproot/modm/ext/cmsis/dsp"),
+        abspath(r"taproot/modm/ext/cmsis/core")
+    ])
     env.AppendUnique(LIBS=HOSTED_LIBS)
 elif args["TARGET_ENV"] == "tests":
     env.AppendUnique(CPPFLAGS=[
@@ -153,6 +157,10 @@ elif args["TARGET_ENV"] == "tests":
         "-DENV_UNIT_TESTS"])
     env.AppendUnique(CPPPATH=[abspath(SRC_TEST_PATH)])
     env.AppendUnique(CPPPATH=[abspath(TAPROOT_TEST_PATH)])
+    env.AppendUnique(CPPPATH=[
+        abspath(r"taproot/modm/ext/cmsis/dsp"),
+        abspath(r"taproot/modm/ext/cmsis/core")
+    ])
     env.AppendUnique(LIBS=GTEST_LIBS)
     env.AppendUnique(LIBS=HOSTED_LIBS)
 
@@ -184,6 +192,85 @@ if "additional-ccflags" in ARGUMENTS:
 
 # Find source files to compile
 sources = env.FindSourceFiles(".", ignorePaths=ignored_dirs, ignoreFiles=ignored_files)
+
+if args["TARGET_ENV"] == "tests" or args["TARGET_ENV"] == "sim":
+    # Cross compile CMSIS arm matrix to be able to use it on the Linux platform
+    flags = {"CCFLAGS": ['$CCFLAGS', '-Wno-sign-compare', '-Wno-double-promotion'], "CFLAGS": ['$CFLAGS', '-fno-strict-aliasing'], "CPPDEFINES": ['$CPPDEFINES', '__FPU_PRESENT=1', 'ARM_MATH_ROUNDING', 'UNALIGNED_SUPPORT_DISABLE', 'ARM_MATH_LOOPUNROLL'], }
+    if args["BUILD_PROFILE"] == "debug": flags["CPPDEFINES"].extend(['ARM_MATH_MATRIX_CHECK']);
+    sources.append(env.Object(r"taproot/modm/ext/cmsis/dsp/MatrixFunctions/arm_mat_add_f32.c", **flags))
+    flags = {"CCFLAGS": ['$CCFLAGS', '-Wno-sign-compare', '-Wno-double-promotion'], "CFLAGS": ['$CFLAGS', '-fno-strict-aliasing'], "CPPDEFINES": ['$CPPDEFINES', '__FPU_PRESENT=1', 'ARM_MATH_ROUNDING', 'UNALIGNED_SUPPORT_DISABLE', 'ARM_MATH_LOOPUNROLL'], }
+    if args["BUILD_PROFILE"] == "debug": flags["CPPDEFINES"].extend(['ARM_MATH_MATRIX_CHECK']);
+    sources.append(env.Object(r"taproot/modm/ext/cmsis/dsp/MatrixFunctions/arm_mat_add_q15.c", **flags))
+    flags = {"CCFLAGS": ['$CCFLAGS', '-Wno-sign-compare', '-Wno-double-promotion'], "CFLAGS": ['$CFLAGS', '-fno-strict-aliasing'], "CPPDEFINES": ['$CPPDEFINES', '__FPU_PRESENT=1', 'ARM_MATH_ROUNDING', 'UNALIGNED_SUPPORT_DISABLE', 'ARM_MATH_LOOPUNROLL'], }
+    if args["BUILD_PROFILE"] == "debug": flags["CPPDEFINES"].extend(['ARM_MATH_MATRIX_CHECK']);
+    sources.append(env.Object(r"taproot/modm/ext/cmsis/dsp/MatrixFunctions/arm_mat_add_q31.c", **flags))
+    flags = {"CCFLAGS": ['$CCFLAGS', '-Wno-sign-compare', '-Wno-double-promotion'], "CFLAGS": ['$CFLAGS', '-fno-strict-aliasing'], "CPPDEFINES": ['$CPPDEFINES', '__FPU_PRESENT=1', 'ARM_MATH_ROUNDING', 'UNALIGNED_SUPPORT_DISABLE', 'ARM_MATH_LOOPUNROLL'], }
+    if args["BUILD_PROFILE"] == "debug": flags["CPPDEFINES"].extend(['ARM_MATH_MATRIX_CHECK']);
+    sources.append(env.Object(r"taproot/modm/ext/cmsis/dsp/MatrixFunctions/arm_mat_cmplx_mult_f32.c", **flags))
+    flags = {"CCFLAGS": ['$CCFLAGS', '-Wno-sign-compare', '-Wno-double-promotion'], "CFLAGS": ['$CFLAGS', '-fno-strict-aliasing'], "CPPDEFINES": ['$CPPDEFINES', '__FPU_PRESENT=1', 'ARM_MATH_ROUNDING', 'UNALIGNED_SUPPORT_DISABLE', 'ARM_MATH_LOOPUNROLL'], }
+    if args["BUILD_PROFILE"] == "debug": flags["CPPDEFINES"].extend(['ARM_MATH_MATRIX_CHECK']);
+    sources.append(env.Object(r"taproot/modm/ext/cmsis/dsp/MatrixFunctions/arm_mat_cmplx_mult_q15.c", **flags))
+    flags = {"CCFLAGS": ['$CCFLAGS', '-Wno-sign-compare', '-Wno-double-promotion'], "CFLAGS": ['$CFLAGS', '-fno-strict-aliasing'], "CPPDEFINES": ['$CPPDEFINES', '__FPU_PRESENT=1', 'ARM_MATH_ROUNDING', 'UNALIGNED_SUPPORT_DISABLE', 'ARM_MATH_LOOPUNROLL'], }
+    if args["BUILD_PROFILE"] == "debug": flags["CPPDEFINES"].extend(['ARM_MATH_MATRIX_CHECK']);
+    sources.append(env.Object(r"taproot/modm/ext/cmsis/dsp/MatrixFunctions/arm_mat_cmplx_mult_q31.c", **flags))
+    flags = {"CCFLAGS": ['$CCFLAGS', '-Wno-sign-compare', '-Wno-double-promotion'], "CFLAGS": ['$CFLAGS', '-fno-strict-aliasing'], "CPPDEFINES": ['$CPPDEFINES', '__FPU_PRESENT=1', 'ARM_MATH_ROUNDING', 'UNALIGNED_SUPPORT_DISABLE', 'ARM_MATH_LOOPUNROLL'], }
+    if args["BUILD_PROFILE"] == "debug": flags["CPPDEFINES"].extend(['ARM_MATH_MATRIX_CHECK']);
+    sources.append(env.Object(r"taproot/modm/ext/cmsis/dsp/MatrixFunctions/arm_mat_init_f32.c", **flags))
+    flags = {"CCFLAGS": ['$CCFLAGS', '-Wno-sign-compare', '-Wno-double-promotion'], "CFLAGS": ['$CFLAGS', '-fno-strict-aliasing'], "CPPDEFINES": ['$CPPDEFINES', '__FPU_PRESENT=1', 'ARM_MATH_ROUNDING', 'UNALIGNED_SUPPORT_DISABLE', 'ARM_MATH_LOOPUNROLL'], }
+    if args["BUILD_PROFILE"] == "debug": flags["CPPDEFINES"].extend(['ARM_MATH_MATRIX_CHECK']);
+    sources.append(env.Object(r"taproot/modm/ext/cmsis/dsp/MatrixFunctions/arm_mat_init_q15.c", **flags))
+    flags = {"CCFLAGS": ['$CCFLAGS', '-Wno-sign-compare', '-Wno-double-promotion'], "CFLAGS": ['$CFLAGS', '-fno-strict-aliasing'], "CPPDEFINES": ['$CPPDEFINES', '__FPU_PRESENT=1', 'ARM_MATH_ROUNDING', 'UNALIGNED_SUPPORT_DISABLE', 'ARM_MATH_LOOPUNROLL'], }
+    if args["BUILD_PROFILE"] == "debug": flags["CPPDEFINES"].extend(['ARM_MATH_MATRIX_CHECK']);
+    sources.append(env.Object(r"taproot/modm/ext/cmsis/dsp/MatrixFunctions/arm_mat_init_q31.c", **flags))
+    flags = {"CCFLAGS": ['$CCFLAGS', '-Wno-sign-compare', '-Wno-double-promotion'], "CFLAGS": ['$CFLAGS', '-fno-strict-aliasing'], "CPPDEFINES": ['$CPPDEFINES', '__FPU_PRESENT=1', 'ARM_MATH_ROUNDING', 'UNALIGNED_SUPPORT_DISABLE', 'ARM_MATH_LOOPUNROLL'], }
+    if args["BUILD_PROFILE"] == "debug": flags["CPPDEFINES"].extend(['ARM_MATH_MATRIX_CHECK']);
+    sources.append(env.Object(r"taproot/modm/ext/cmsis/dsp/MatrixFunctions/arm_mat_inverse_f32.c", **flags))
+    flags = {"CCFLAGS": ['$CCFLAGS', '-Wno-sign-compare', '-Wno-double-promotion'], "CFLAGS": ['$CFLAGS', '-fno-strict-aliasing'], "CPPDEFINES": ['$CPPDEFINES', '__FPU_PRESENT=1', 'ARM_MATH_ROUNDING', 'UNALIGNED_SUPPORT_DISABLE', 'ARM_MATH_LOOPUNROLL'], }
+    if args["BUILD_PROFILE"] == "debug": flags["CPPDEFINES"].extend(['ARM_MATH_MATRIX_CHECK']);
+    sources.append(env.Object(r"taproot/modm/ext/cmsis/dsp/MatrixFunctions/arm_mat_inverse_f64.c", **flags))
+    flags = {"CCFLAGS": ['$CCFLAGS', '-Wno-sign-compare', '-Wno-double-promotion'], "CFLAGS": ['$CFLAGS', '-fno-strict-aliasing'], "CPPDEFINES": ['$CPPDEFINES', '__FPU_PRESENT=1', 'ARM_MATH_ROUNDING', 'UNALIGNED_SUPPORT_DISABLE', 'ARM_MATH_LOOPUNROLL'], }
+    if args["BUILD_PROFILE"] == "debug": flags["CPPDEFINES"].extend(['ARM_MATH_MATRIX_CHECK']);
+    sources.append(env.Object(r"taproot/modm/ext/cmsis/dsp/MatrixFunctions/arm_mat_mult_f32.c", **flags))
+    flags = {"CCFLAGS": ['$CCFLAGS', '-Wno-sign-compare', '-Wno-double-promotion'], "CFLAGS": ['$CFLAGS', '-fno-strict-aliasing'], "CPPDEFINES": ['$CPPDEFINES', '__FPU_PRESENT=1', 'ARM_MATH_ROUNDING', 'UNALIGNED_SUPPORT_DISABLE', 'ARM_MATH_LOOPUNROLL'], }
+    if args["BUILD_PROFILE"] == "debug": flags["CPPDEFINES"].extend(['ARM_MATH_MATRIX_CHECK']);
+    sources.append(env.Object(r"taproot/modm/ext/cmsis/dsp/MatrixFunctions/arm_mat_mult_fast_q15.c", **flags))
+    flags = {"CCFLAGS": ['$CCFLAGS', '-Wno-sign-compare', '-Wno-double-promotion'], "CFLAGS": ['$CFLAGS', '-fno-strict-aliasing'], "CPPDEFINES": ['$CPPDEFINES', '__FPU_PRESENT=1', 'ARM_MATH_ROUNDING', 'UNALIGNED_SUPPORT_DISABLE', 'ARM_MATH_LOOPUNROLL'], }
+    if args["BUILD_PROFILE"] == "debug": flags["CPPDEFINES"].extend(['ARM_MATH_MATRIX_CHECK']);
+    sources.append(env.Object(r"taproot/modm/ext/cmsis/dsp/MatrixFunctions/arm_mat_mult_fast_q31.c", **flags))
+    flags = {"CCFLAGS": ['$CCFLAGS', '-Wno-sign-compare', '-Wno-double-promotion'], "CFLAGS": ['$CFLAGS', '-fno-strict-aliasing'], "CPPDEFINES": ['$CPPDEFINES', '__FPU_PRESENT=1', 'ARM_MATH_ROUNDING', 'UNALIGNED_SUPPORT_DISABLE', 'ARM_MATH_LOOPUNROLL'], }
+    if args["BUILD_PROFILE"] == "debug": flags["CPPDEFINES"].extend(['ARM_MATH_MATRIX_CHECK']);
+    sources.append(env.Object(r"taproot/modm/ext/cmsis/dsp/MatrixFunctions/arm_mat_mult_q15.c", **flags))
+    flags = {"CCFLAGS": ['$CCFLAGS', '-Wno-sign-compare', '-Wno-double-promotion'], "CFLAGS": ['$CFLAGS', '-fno-strict-aliasing'], "CPPDEFINES": ['$CPPDEFINES', '__FPU_PRESENT=1', 'ARM_MATH_ROUNDING', 'UNALIGNED_SUPPORT_DISABLE', 'ARM_MATH_LOOPUNROLL'], }
+    if args["BUILD_PROFILE"] == "debug": flags["CPPDEFINES"].extend(['ARM_MATH_MATRIX_CHECK']);
+    sources.append(env.Object(r"taproot/modm/ext/cmsis/dsp/MatrixFunctions/arm_mat_mult_q31.c", **flags))
+    flags = {"CCFLAGS": ['$CCFLAGS', '-Wno-sign-compare', '-Wno-double-promotion'], "CFLAGS": ['$CFLAGS', '-fno-strict-aliasing'], "CPPDEFINES": ['$CPPDEFINES', '__FPU_PRESENT=1', 'ARM_MATH_ROUNDING', 'UNALIGNED_SUPPORT_DISABLE', 'ARM_MATH_LOOPUNROLL'], }
+    if args["BUILD_PROFILE"] == "debug": flags["CPPDEFINES"].extend(['ARM_MATH_MATRIX_CHECK']);
+    sources.append(env.Object(r"taproot/modm/ext/cmsis/dsp/MatrixFunctions/arm_mat_scale_f32.c", **flags))
+    flags = {"CCFLAGS": ['$CCFLAGS', '-Wno-sign-compare', '-Wno-double-promotion'], "CFLAGS": ['$CFLAGS', '-fno-strict-aliasing'], "CPPDEFINES": ['$CPPDEFINES', '__FPU_PRESENT=1', 'ARM_MATH_ROUNDING', 'UNALIGNED_SUPPORT_DISABLE', 'ARM_MATH_LOOPUNROLL'], }
+    if args["BUILD_PROFILE"] == "debug": flags["CPPDEFINES"].extend(['ARM_MATH_MATRIX_CHECK']);
+    sources.append(env.Object(r"taproot/modm/ext/cmsis/dsp/MatrixFunctions/arm_mat_scale_q15.c", **flags))
+    flags = {"CCFLAGS": ['$CCFLAGS', '-Wno-sign-compare', '-Wno-double-promotion'], "CFLAGS": ['$CFLAGS', '-fno-strict-aliasing'], "CPPDEFINES": ['$CPPDEFINES', '__FPU_PRESENT=1', 'ARM_MATH_ROUNDING', 'UNALIGNED_SUPPORT_DISABLE', 'ARM_MATH_LOOPUNROLL'], }
+    if args["BUILD_PROFILE"] == "debug": flags["CPPDEFINES"].extend(['ARM_MATH_MATRIX_CHECK']);
+    sources.append(env.Object(r"taproot/modm/ext/cmsis/dsp/MatrixFunctions/arm_mat_scale_q31.c", **flags))
+    flags = {"CCFLAGS": ['$CCFLAGS', '-Wno-sign-compare', '-Wno-double-promotion'], "CFLAGS": ['$CFLAGS', '-fno-strict-aliasing'], "CPPDEFINES": ['$CPPDEFINES', '__FPU_PRESENT=1', 'ARM_MATH_ROUNDING', 'UNALIGNED_SUPPORT_DISABLE', 'ARM_MATH_LOOPUNROLL'], }
+    if args["BUILD_PROFILE"] == "debug": flags["CPPDEFINES"].extend(['ARM_MATH_MATRIX_CHECK']);
+    sources.append(env.Object(r"taproot/modm/ext/cmsis/dsp/MatrixFunctions/arm_mat_sub_f32.c", **flags))
+    flags = {"CCFLAGS": ['$CCFLAGS', '-Wno-sign-compare', '-Wno-double-promotion'], "CFLAGS": ['$CFLAGS', '-fno-strict-aliasing'], "CPPDEFINES": ['$CPPDEFINES', '__FPU_PRESENT=1', 'ARM_MATH_ROUNDING', 'UNALIGNED_SUPPORT_DISABLE', 'ARM_MATH_LOOPUNROLL'], }
+    if args["BUILD_PROFILE"] == "debug": flags["CPPDEFINES"].extend(['ARM_MATH_MATRIX_CHECK']);
+    sources.append(env.Object(r"taproot/modm/ext/cmsis/dsp/MatrixFunctions/arm_mat_sub_q15.c", **flags))
+    flags = {"CCFLAGS": ['$CCFLAGS', '-Wno-sign-compare', '-Wno-double-promotion'], "CFLAGS": ['$CFLAGS', '-fno-strict-aliasing'], "CPPDEFINES": ['$CPPDEFINES', '__FPU_PRESENT=1', 'ARM_MATH_ROUNDING', 'UNALIGNED_SUPPORT_DISABLE', 'ARM_MATH_LOOPUNROLL'], }
+    if args["BUILD_PROFILE"] == "debug": flags["CPPDEFINES"].extend(['ARM_MATH_MATRIX_CHECK']);
+    sources.append(env.Object(r"taproot/modm/ext/cmsis/dsp/MatrixFunctions/arm_mat_sub_q31.c", **flags))
+    flags = {"CCFLAGS": ['$CCFLAGS', '-Wno-sign-compare', '-Wno-double-promotion'], "CFLAGS": ['$CFLAGS', '-fno-strict-aliasing'], "CPPDEFINES": ['$CPPDEFINES', '__FPU_PRESENT=1', 'ARM_MATH_ROUNDING', 'UNALIGNED_SUPPORT_DISABLE', 'ARM_MATH_LOOPUNROLL'], }
+    if args["BUILD_PROFILE"] == "debug": flags["CPPDEFINES"].extend(['ARM_MATH_MATRIX_CHECK']);
+    sources.append(env.Object(r"taproot/modm/ext/cmsis/dsp/MatrixFunctions/arm_mat_trans_f32.c", **flags))
+    flags = {"CCFLAGS": ['$CCFLAGS', '-Wno-sign-compare', '-Wno-double-promotion'], "CFLAGS": ['$CFLAGS', '-fno-strict-aliasing'], "CPPDEFINES": ['$CPPDEFINES', '__FPU_PRESENT=1', 'ARM_MATH_ROUNDING', 'UNALIGNED_SUPPORT_DISABLE', 'ARM_MATH_LOOPUNROLL'], }
+    if args["BUILD_PROFILE"] == "debug": flags["CPPDEFINES"].extend(['ARM_MATH_MATRIX_CHECK']);
+    sources.append(env.Object(r"taproot/modm/ext/cmsis/dsp/MatrixFunctions/arm_mat_trans_q15.c", **flags))
+    flags = {"CCFLAGS": ['$CCFLAGS', '-Wno-sign-compare', '-Wno-double-promotion'], "CFLAGS": ['$CFLAGS', '-fno-strict-aliasing'], "CPPDEFINES": ['$CPPDEFINES', '__FPU_PRESENT=1', 'ARM_MATH_ROUNDING', 'UNALIGNED_SUPPORT_DISABLE', 'ARM_MATH_LOOPUNROLL'], }
+    if args["BUILD_PROFILE"] == "debug": flags["CPPDEFINES"].extend(['ARM_MATH_MATRIX_CHECK']);
+    sources.append(env.Object(r"taproot/modm/ext/cmsis/dsp/MatrixFunctions/arm_mat_trans_q31.c", **flags))
+
 
 
 if args["TARGET_ENV"] == "hardware":

--- a/aimbots-dev/src/utils/common_types.hpp
+++ b/aimbots-dev/src/utils/common_types.hpp
@@ -24,4 +24,4 @@ template <typename T, uint8_t ROWS, uint8_t COLUMNS>
 using Matrix = modm::Matrix<T, ROWS, COLUMNS>;
 
 template <uint8_t ROWS, uint8_t COLUMNS>
-using linAlgMatrix = tap::algorithms::CMSISMat<ROWS, COLUMNS>;
+using TapMatrix = tap::algorithms::CMSISMat<ROWS, COLUMNS>;

--- a/aimbots-dev/src/utils/common_types.hpp
+++ b/aimbots-dev/src/utils/common_types.hpp
@@ -5,6 +5,8 @@
 #include <tap/communication/can/can_bus.hpp>
 #include <tap/motor/dji_motor.hpp>
 
+
+#include "tap/algorithms/matrix_utils.hpp"
 #include "modm/math/matrix.hpp"
 #include "tap/control/chassis/power_limiter.hpp"
 
@@ -20,3 +22,6 @@ using DJIMotor = tap::motor::DjiMotor;
 
 template <typename T, uint8_t ROWS, uint8_t COLUMNS>
 using Matrix = modm::Matrix<T, ROWS, COLUMNS>;
+
+template <uint8_t ROWS, uint8_t COLUMNS>
+using linAlgMatrix = tap::algorithms::CMSISMat<ROWS, COLUMNS>;

--- a/aimbots-dev/src/utils/math/mecanum_drive.cpp
+++ b/aimbots-dev/src/utils/math/mecanum_drive.cpp
@@ -1,0 +1,81 @@
+#include "utils/common_types.hpp"
+
+namespace MecanumDrive{
+    Matrix<float,4,3> createJacobian(float length, float width){
+        const float j[12] = {
+            -1,1,length+width,
+            1, 1,-(length+width),
+            -1,1,length+width,
+            1, 1,-(length+width)
+        };
+
+        Matrix<float,4,3> jacobian(j);
+
+        // {
+        //     {-1,1, length+width     },
+        //     {1 ,1, -(length+width)  },
+        //     {-1,1, length+width     },
+        //     {1, 1, -(length+width)  }
+        // };
+        return jacobian;
+    };
+
+    Matrix<float,3,3> createRotationMatrix(float theta){
+        const float r[9] = {
+            cos(theta), -sin(theta), 0,
+            sin(theta), cos(theta), 0,
+            0,          0,          1
+        };
+        
+        Matrix<float,3,3> rotationMatrix(r);
+        // {
+        //     {cos(theta),-sin(theta),0},
+        //     {sin(theta),cos(theta),0},
+        //     {0,0,1}
+        // };
+
+        return rotationMatrix;
+    };
+
+    Matrix<float,4,1> mecanumKinematics(float dx, float dy, float dtheta, Matrix<float,4,3> jacobian, Matrix<float,3,3> rotatiion){
+        const float c[3] = {
+            dx,
+            dy,
+            dtheta
+        };
+        Matrix <float,3,1> cx(c);
+        // cx = {
+        //     {dx},
+        //     {dy},
+        //     {dtheta}
+        // };
+        
+        Matrix<float,4,1> wheelVeloicty;
+
+        wheelVeloicty = jacobian * rotatiion * cx;
+
+        return wheelVeloicty;
+    }
+
+Matrix<float,4,1> mecanumKinematics(float dx, float dy, float dtheta, Matrix<float,4,3> jacobian){
+        const float c[3] = {
+            dx,
+            dy,
+            dtheta
+        };
+        Matrix <float,3,1> cx(c);
+        // cx = {
+        //     {dx},
+        //     {dy},
+        //     {dtheta}
+        // };
+        
+        Matrix<float,4,1> wheelVeloicty;
+
+        wheelVeloicty = jacobian * cx;
+
+        return wheelVeloicty;
+    }
+
+
+}; // namespace MecanumDrive

--- a/aimbots-dev/src/utils/math/mecanum_drive.hpp
+++ b/aimbots-dev/src/utils/math/mecanum_drive.hpp
@@ -1,0 +1,10 @@
+#pragma once
+#include "utils/common_types.hpp"
+
+namespace MecanumDrive {
+            Matrix<float,4,1> mecanumKinematics(float dx, float dy, float dtheta, Matrix<float,4,3> jacobian, Matrix<float,3,3> rotatiion);
+            Matrix<float,4,1> mecanumKinematics(float dx, float dy, float dtheta, Matrix<float,4,3> jacobian);
+            Matrix<float,4,3> createJacobian(float length, float width);
+            Matrix<float,3,3> createRotationMatrix(float theta);
+            
+};

--- a/aimbots-dev/src/utils/math/swerve_drive.cpp
+++ b/aimbots-dev/src/utils/math/swerve_drive.cpp
@@ -6,8 +6,8 @@
 
 namespace SwerveDrive
 {
-    linAlgMatrix<4,2> caluclateSwerve(float dx, float dy, float dtheta){
-        linAlgMatrix<4,2> power;
+    TapMatrix<4,2> caluclateSwerve(float dx, float dy, float dtheta){
+        TapMatrix<4,2> power;
 
             const float c[3 * 1] = {
         dx,
@@ -15,7 +15,7 @@ namespace SwerveDrive
         dtheta
     
         };
-        linAlgMatrix <3,1> cx;
+        TapMatrix <3,1> cx;
         cx.copyData(c);
 
         float l =30.0f, w = 30.0f;
@@ -34,7 +34,7 @@ namespace SwerveDrive
         //https://www.chiefdelphi.com/t/swerve-drive-direct-and-reverse-kinematics/395803/3
         //what the math is based upon ^^^
 
-        linAlgMatrix <8,3> g;
+        TapMatrix <8,3> g;
         // float theta = 0
         g.copyData(test);
 
@@ -44,11 +44,11 @@ namespace SwerveDrive
         //     0,          0,          1
         // };
 
-        // linAlgMatrix <3,3> R(r);
+        // TapMatrix <3,3> R(r);
 
-        linAlgMatrix<8,1> velocity = g * cx;
+        TapMatrix<8,1> velocity = g * cx;
 
-        linAlgMatrix<4,2> velocityOrganized;
+        TapMatrix<4,2> velocityOrganized;
         for (size_t i = 0; i < 8; i+=2)
         {
             velocityOrganized.data[i] = velocity.data[i];
@@ -56,7 +56,7 @@ namespace SwerveDrive
 
         }
         
-        linAlgMatrix<4,2> power_heading;
+        TapMatrix<4,2> power_heading;
         for (size_t i = 0; i < 8; i+=2)
         {
             power_heading.data[i] = sqrt(velocity.data[i] * velocity.data[i] + velocity.data[i+1] * velocity.data[i+1]);

--- a/aimbots-dev/src/utils/math/swerve_drive.cpp
+++ b/aimbots-dev/src/utils/math/swerve_drive.cpp
@@ -2,52 +2,83 @@
 
 #include "utils/math/swerve_drive.hpp"
 #include "utils/math/math.cpp"
+#include <math.h> 
 
 namespace SwerveDrive
 {
-    Matrix<float,4,2> caluclateSwerve(float dx, float dy, float dtheta){
-        // float Vx_1, Vy_1, Vx_2, Vy_2, Vx_3, Vy_3, Vx_4, Vy_4;
-        // float Vw_1, Vw_2, Vw_3, Vw_4;
+    linAlgMatrix<4,2> caluclateSwerve(float dx, float dy, float dtheta){
+        linAlgMatrix<4,2> power;
 
-        // Vx_1 = Vx_2 = Vx_3 = Vx_4 = 1.0f;
-        // Vy_1 = Vy_2 = Vy_3 = Vy_4 = 1.0f;
-
-        // Vw_1 = Vw_2 = Vw_3 = Vw_4 = 1 / theta;
-
-        Matrix<float,4,2> power;
-
-        const float c[3] = {
-            dx,
-            dy,
-            dtheta
+            const float c[3 * 1] = {
+        dx,
+        dy,
+        dtheta
+    
         };
-        Matrix <float,3,1> cx(c);
+        linAlgMatrix <3,1> cx;
+        cx.copyData(c);
 
-        float l =1.0f, w = 1.0f;
+        float l =30.0f, w = 30.0f;
 
-        const float test[6] = {
-            1,0,l,
-            0,1,w
+        const float test[8*3] = {
+            1,0,-l,
+            0,1,w,
+            1,0,-l,
+            0,1,w,
+            1,0,-l,
+            0,1,w,
+            1,0,-l,
+            0,1,w,
         };
 
         //https://www.chiefdelphi.com/t/swerve-drive-direct-and-reverse-kinematics/395803/3
         //what the math is based upon ^^^
 
-        Matrix <float,2,3> g(test);
+        linAlgMatrix <8,3> g;
+        // float theta = 0
+        g.copyData(test);
 
-        Matrix<float,2,1> v1Vel = g * cx;
+        //     const float r[3*3] = {
+        //     cos(theta), -sin(theta), 0,
+        //     sin(theta), cos(theta), 0,
+        //     0,          0,          1
+        // };
 
-        // Matrix<float,1,2> v1vel_t = math::transposeAll(v1Vel);
+        // linAlgMatrix <3,3> R(r);
 
-        Matrix<float,4,2> power_heading;
+        linAlgMatrix<8,1> velocity = g * cx;
 
-        // float velocity = modm::Matrix::norm(v1Vel);
-        // power_heading.set(0,0,);
+        linAlgMatrix<4,2> velocityOrganized;
+        for (size_t i = 0; i < 8; i+=2)
+        {
+            velocityOrganized.data[i] = velocity.data[i];
+            velocityOrganized.data[i+1] = velocity.data[i+1];
 
+        }
+        
+        linAlgMatrix<4,2> power_heading;
+        for (size_t i = 0; i < 8; i+=2)
+        {
+            power_heading.data[i] = sqrt(velocity.data[i] * velocity.data[i] + velocity.data[i+1] * velocity.data[i+1]);
+            power_heading.data[i+1] = atan2 (velocity.data[i+1], velocity.data[i]);
+        }
 
+        // for loop that get the largerst value of the matrix
+        float max = 0;
+        for (size_t i = 0; i < 4; i++)
+        {
+            if (power_heading.data[i*2] > max)
+            {
+                max = power_heading.data[i*2];
+            }
+        }
 
+        for (size_t i = 0; i < 4; i++)
+        {
+            power_heading.data[i*2] = power_heading.data[i*2] / max;
+        }
 
-        // power[0][0] = sqrt((Vy_1-Vw_1*cos(theta))*(Vy_1-Vw_1*cos(theta)) + (Vx_1+Vw_1*sin(theta))*(Vx_1+Vw_1*sin(theta)));
+        return power_heading;
     }
 
 } // namespace SwerveDrive

--- a/aimbots-dev/src/utils/math/swerve_drive.cpp
+++ b/aimbots-dev/src/utils/math/swerve_drive.cpp
@@ -1,0 +1,19 @@
+#include "utils/common_types.hpp"
+
+namespace SwerveDrive
+{
+    Matrix<float,4,2> caluclateSwerve(float x, float y, float theta){
+        float Vx_1, Vy_1, Vx_2, Vy_2, Vx_3, Vy_3, Vx_4, Vy_4;
+        float Vw_1, Vw_2, Vw_3, Vw_4;
+
+        Vx_1 = Vx_2 = Vx_3 = Vx_4 = 1.0f;
+        Vy_1 = Vy_2 = Vy_3 = Vy_4 = 1.0f;
+
+        Vw_1 = Vw_2 = Vw_3 = Vw_4 = 1 / theta;
+
+        Matrix<float,4,2> power;
+
+        power[0][0] = sqrt((Vy_1-Vw_1*cos(theta))*(Vy_1-Vw_1*cos(theta)) + (Vx_1+Vw_1*sin(theta))*(Vx_1+Vw_1*sin(theta)));
+    }
+
+} // namespace SwerveDrive

--- a/aimbots-dev/src/utils/math/swerve_drive.cpp
+++ b/aimbots-dev/src/utils/math/swerve_drive.cpp
@@ -1,19 +1,53 @@
 #include "utils/common_types.hpp"
 
+#include "utils/math/swerve_drive.hpp"
+#include "utils/math/math.cpp"
+
 namespace SwerveDrive
 {
-    Matrix<float,4,2> caluclateSwerve(float x, float y, float theta){
-        float Vx_1, Vy_1, Vx_2, Vy_2, Vx_3, Vy_3, Vx_4, Vy_4;
-        float Vw_1, Vw_2, Vw_3, Vw_4;
+    Matrix<float,4,2> caluclateSwerve(float dx, float dy, float dtheta){
+        // float Vx_1, Vy_1, Vx_2, Vy_2, Vx_3, Vy_3, Vx_4, Vy_4;
+        // float Vw_1, Vw_2, Vw_3, Vw_4;
 
-        Vx_1 = Vx_2 = Vx_3 = Vx_4 = 1.0f;
-        Vy_1 = Vy_2 = Vy_3 = Vy_4 = 1.0f;
+        // Vx_1 = Vx_2 = Vx_3 = Vx_4 = 1.0f;
+        // Vy_1 = Vy_2 = Vy_3 = Vy_4 = 1.0f;
 
-        Vw_1 = Vw_2 = Vw_3 = Vw_4 = 1 / theta;
+        // Vw_1 = Vw_2 = Vw_3 = Vw_4 = 1 / theta;
 
         Matrix<float,4,2> power;
 
-        power[0][0] = sqrt((Vy_1-Vw_1*cos(theta))*(Vy_1-Vw_1*cos(theta)) + (Vx_1+Vw_1*sin(theta))*(Vx_1+Vw_1*sin(theta)));
+        const float c[3] = {
+            dx,
+            dy,
+            dtheta
+        };
+        Matrix <float,3,1> cx(c);
+
+        float l =1.0f, w = 1.0f;
+
+        const float test[6] = {
+            1,0,l,
+            0,1,w
+        };
+
+        //https://www.chiefdelphi.com/t/swerve-drive-direct-and-reverse-kinematics/395803/3
+        //what the math is based upon ^^^
+
+        Matrix <float,2,3> g(test);
+
+        Matrix<float,2,1> v1Vel = g * cx;
+
+        // Matrix<float,1,2> v1vel_t = math::transposeAll(v1Vel);
+
+        Matrix<float,4,2> power_heading;
+
+        // float velocity = modm::Matrix::norm(v1Vel);
+        // power_heading.set(0,0,);
+
+
+
+
+        // power[0][0] = sqrt((Vy_1-Vw_1*cos(theta))*(Vy_1-Vw_1*cos(theta)) + (Vx_1+Vw_1*sin(theta))*(Vx_1+Vw_1*sin(theta)));
     }
 
 } // namespace SwerveDrive

--- a/aimbots-dev/src/utils/math/swerve_drive.hpp
+++ b/aimbots-dev/src/utils/math/swerve_drive.hpp
@@ -2,7 +2,7 @@
 #include "utils/common_types.hpp"
 
 namespace SwerveDrive{
-    Matrix<float,4,2> caluclateSwerve(float x, float y, float theta);
+    linAlgMatrix<4,2> caluclateSwerve(float x, float y, float theta);
     
 
 } // namespace SwerveDrive

--- a/aimbots-dev/src/utils/math/swerve_drive.hpp
+++ b/aimbots-dev/src/utils/math/swerve_drive.hpp
@@ -2,7 +2,7 @@
 #include "utils/common_types.hpp"
 
 namespace SwerveDrive{
-    linAlgMatrix<4,2> caluclateSwerve(float x, float y, float theta);
+    TapMatrix<4,2> caluclateSwerve(float x, float y, float theta);
     
 
 } // namespace SwerveDrive

--- a/aimbots-dev/src/utils/math/swerve_drive.hpp
+++ b/aimbots-dev/src/utils/math/swerve_drive.hpp
@@ -1,0 +1,12 @@
+#pragma once
+#include "utils/common_types.hpp"
+
+namespace SwerveDrive{
+    Matrix<float,4,2> caluclateSwerve(float x, float y, float theta);
+    
+
+} // namespace SwerveDrive
+
+
+
+

--- a/aimbots-dev/test/my_first_test.cpp
+++ b/aimbots-dev/test/my_first_test.cpp
@@ -17,8 +17,8 @@
  * along with aimbots-dev.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include <gtest/gtest.h>
+// #include <gtest/gtest.h>
 
-#include "my_first_file.hpp"
+// #include "my_first_file.hpp"
 
-TEST(hello, world) { EXPECT_EQ(3, sum(1, 2)); }
+// TEST(hello, world) { EXPECT_EQ(3, sum(1, 2)); }


### PR DESCRIPTION
Works very similarly to how mecanum math works. 

`Swerve_Drive.cpp` 
We have a transformation matrix that takes in the values for the size of the robots and it gets multiplied by the robots velocity vector. This returns a 8x1 matrix that gives the robots velocity per wheel in the Vx and Vy directions.  Then we take those two and get a 4x2 matrix where the first column is the power and the second one is the wheel heading.

`returns power_heading` which is a 4x2 matrix the first column is locked between 0-1 and the second is radians from 0 - 2pi.

This has been united tested and seems to work for all generally cases. A rotration matrix might be needed for doing _tokyo drifting_ but that will bee seen once the robots are actually built and tested.

**This does not solve for the 180 degree issue**

All of the math is based on this [article](https://www.chiefdelphi.com/t/swerve-drive-direct-and-reverse-kinematics/395803/3)

*Also settings issues need to be looked upon during merge. This will happen every time i merge with develop*