### PR TITLE
gimbal: Change when the motor output is set

### DIFF
--- a/aimbots-src/src/subsystems/gimbal/gimbal.hpp
+++ b/aimbots-src/src/subsystems/gimbal/gimbal.hpp
@@ -59,6 +59,9 @@ class GimbalSubsystem : public tap::control::Subsystem {
     float targetYawAngle;    // in Radians
     float targetPitchAngle;  // in Radians
 
+    uint16_t desiredYawMotorOutput;
+    uint16_t desiredPitchMotorOutput;
+
     static constexpr CANBus GIMBAL_BUS = CANBus::CAN_BUS1;
 };
 


### PR DESCRIPTION
We now only call `DJIMotor::setDesiredOutput()` in
`GimbalSubsystem::refresh`.